### PR TITLE
Add Telebugs.config

### DIFF
--- a/lib/telebugs.rb
+++ b/lib/telebugs.rb
@@ -30,6 +30,10 @@ module Telebugs
       yield Config.instance
     end
 
+    def config
+      Config.instance
+    end
+
     def report(error)
       Reporter.instance.report(error)
     end

--- a/test/test_config.rb
+++ b/test/test_config.rb
@@ -4,25 +4,25 @@ require "test_helper"
 
 class TestConfig < Minitest::Test
   def teardown
-    Telebugs::Config.instance.reset
+    Telebugs.config.reset
   end
 
   def test_api_key
     Telebugs.configure { |c| c.api_key = "12345:abcdef" }
 
-    assert_equal "12345:abcdef", Telebugs::Config.instance.api_key
+    assert_equal "12345:abcdef", Telebugs.config.api_key
   end
 
   def test_error_api_url
     Telebugs.configure { |c| c.api_url = "example.com" }
 
-    assert_equal URI("example.com"), Telebugs::Config.instance.api_url
+    assert_equal URI("example.com"), Telebugs.config.api_url
   end
 
   def test_root_directory
     Telebugs.configure { |c| c.root_directory = "/tmp" }
 
-    assert_equal "/tmp", Telebugs::Config.instance.root_directory
+    assert_equal "/tmp", Telebugs.config.root_directory
   end
 
   def test_middleware
@@ -32,6 +32,6 @@ class TestConfig < Minitest::Test
       c.middleware.use middleware_class.new
     end
 
-    assert_equal 1, Telebugs::Config.instance.middleware.middlewares.size
+    assert_equal 1, Telebugs.config.middleware.middlewares.size
   end
 end

--- a/test/test_reporter.rb
+++ b/test/test_reporter.rb
@@ -11,11 +11,11 @@ end
 class TestReporter < Minitest::Test
   def teardown
     WebMock.reset!
-    Telebugs::Config.instance.reset
+    Telebugs.config.reset
   end
 
   def test_report_returns_a_promise_that_resolves_to_a_hash
-    stub = stub_request(:post, Telebugs::Config.instance.api_url)
+    stub = stub_request(:post, Telebugs.config.api_url)
       .to_return(status: 201, body: {id: "123"}.to_json)
 
     p = Telebugs::Reporter.new.report(StandardError.new)
@@ -25,7 +25,7 @@ class TestReporter < Minitest::Test
   end
 
   def test_reporter_returns_a_promise_that_rejects_on_http_error
-    stub = stub_request(:post, Telebugs::Config.instance.api_url)
+    stub = stub_request(:post, Telebugs.config.api_url)
       .to_return(status: 500)
 
     p = Telebugs::Reporter.new.report(StandardError.new)
@@ -36,7 +36,7 @@ class TestReporter < Minitest::Test
   end
 
   def test_reporter_does_not_send_ignored_errors
-    stub = stub_request(:post, Telebugs::Config.instance.api_url)
+    stub = stub_request(:post, Telebugs.config.api_url)
       .to_return(status: 201, body: {id: "123"}.to_json)
 
     Telebugs.configure do |c|

--- a/test/test_sender.rb
+++ b/test/test_sender.rb
@@ -4,14 +4,14 @@ require "test_helper"
 
 class TestSender < Minitest::Test
   def teardown
-    Telebugs::Config.instance.reset
+    Telebugs.config.reset
     WebMock.reset!
   end
 
   def test_send_attaches_correct_authorization_headers
     Telebugs.configure { |c| c.api_key = "12345:abcdef" }
 
-    stub = stub_request(:post, Telebugs::Config.instance.api_url)
+    stub = stub_request(:post, Telebugs.config.api_url)
       .to_return(status: 201, body: {id: "123"}.to_json)
 
     Telebugs::Sender.new.send({"errors" => []})
@@ -27,7 +27,7 @@ class TestSender < Minitest::Test
   end
 
   def test_send_raises_http_error_when_response_code_is_not_created
-    stub = stub_request(:post, Telebugs::Config.instance.api_url)
+    stub = stub_request(:post, Telebugs.config.api_url)
       .to_return(status: 500, body: {"error" => "oops"}.to_json)
 
     assert_raises(Telebugs::HTTPError) do

--- a/test/test_telebugs.rb
+++ b/test/test_telebugs.rb
@@ -4,7 +4,7 @@ require "test_helper"
 
 class TestTelebugs < Minitest::Test
   def teardown
-    Telebugs::Config.instance.reset
+    Telebugs.config.reset
     WebMock.reset!
   end
 
@@ -19,11 +19,11 @@ class TestTelebugs < Minitest::Test
       config.api_key = key
     end
 
-    assert_equal key, Telebugs::Config.instance.api_key
+    assert_equal key, Telebugs.config.api_key
   end
 
   def test_report_returns_a_fullfilled_promise_when_request_succeeds
-    stub_request(:post, Telebugs::Config.instance.api_url)
+    stub_request(:post, Telebugs.config.api_url)
       .to_return(status: 201, body: {id: "123"}.to_json)
 
     p = Telebugs.report(StandardError.new)
@@ -33,11 +33,15 @@ class TestTelebugs < Minitest::Test
   end
 
   def test_report_returns_a_rejected_promise_when_request_fails
-    stub_request(:post, Telebugs::Config.instance.api_url).to_return(status: 500)
+    stub_request(:post, Telebugs.config.api_url).to_return(status: 500)
 
     p = Telebugs.report(StandardError.new)
     p.wait
 
     assert p.rejected?
+  end
+
+  def test_config_exposes_the_default_config
+    assert_match(/telebugs\.com/, Telebugs.config.api_url.to_s)
   end
 end


### PR DESCRIPTION
This eases tests for telebugs-rails. We no longer need to poke private Telebugs lib APIs.