### PR TITLE
Make it possible to delete middleware

### DIFF
--- a/lib/telebugs/middleware_stack.rb
+++ b/lib/telebugs/middleware_stack.rb
@@ -21,6 +21,10 @@ module Telebugs
       @middlewares = (@middlewares << new_middleware).sort_by(&:weight).reverse
     end
 
+    def delete(middleware_class)
+      @middlewares.delete_if { |middleware| middleware.instance_of?(middleware_class) }
+    end
+
     def call(report)
       @middlewares.each do |middleware|
         middleware.call(report)

--- a/test/test_middleware_stack.rb
+++ b/test/test_middleware_stack.rb
@@ -54,4 +54,14 @@ class TestMiddlewareStack < Minitest::Test
       stack.middlewares.map(&:class)
     )
   end
+
+  def test_delete
+    stack = Telebugs::MiddlewareStack.new
+    stack.use TestFilteringMiddleware.new
+    stack.use TestStartLineMiddleware.new
+
+    stack.delete TestFilteringMiddleware
+
+    assert_equal [TestStartLineMiddleware], stack.middlewares.map(&:class)
+  end
 end


### PR DESCRIPTION
Gotcha: If there are two instances of the same middleware, both of them will be deleted.