### PR TITLE
Mark frames that are inside root directory

### DIFF
--- a/lib/telebugs/middleware/root_directory_filter.rb
+++ b/lib/telebugs/middleware/root_directory_filter.rb
@@ -14,6 +14,7 @@ module Telebugs
             next unless (file = frame[:file])
             next unless file.start_with?(@root_directory)
 
+            frame[:root_dir] = true
             file.sub!(/#{@root_directory}\/?/, "")
           end
         end

--- a/test/middleware/test_root_directory_filter.rb
+++ b/test/middleware/test_root_directory_filter.rb
@@ -17,6 +17,8 @@ class TestRootDirectoryFilter < Minitest::Test
     report = Telebugs::Report.new(e)
     Telebugs::Middleware::RootDirectoryFilter.new(root_directory).call(report)
 
-    assert_equal "app/models/user.rb", report.data[:errors][0][:backtrace][0][:file]
+    frame = report.data[:errors][0][:backtrace][0]
+    assert_equal "app/models/user.rb", frame[:file]
+    assert frame[:root_dir]
   end
 end


### PR DESCRIPTION
The backend will treat these frames in a special way.